### PR TITLE
Transmit-only clients no longer have to enable receiver before enabling transmitter

### DIFF
--- a/Ports.h
+++ b/Ports.h
@@ -7,7 +7,7 @@
 #if ARDUINO>=100
 #include <Arduino.h> // Arduino 1.0
 #else
-#include <Wprogram.h> // Arduino 0022
+#include <WProgram.h> // Arduino 0022
 #endif
 #include <stdint.h>
 #include <avr/pgmspace.h>

--- a/PortsBMP085.cpp
+++ b/PortsBMP085.cpp
@@ -9,7 +9,7 @@
 #if ARDUINO>=100
 #include <Arduino.h> // Arduino 1.0
 #else
-#include <Wprogram.h> // Arduino 0022
+#include <WProgram.h> // Arduino 0022
 #endif
 
 uint8_t BMP085::startMeas(uint8_t type) const {

--- a/PortsLCD.cpp
+++ b/PortsLCD.cpp
@@ -5,7 +5,7 @@
 #if ARDUINO>=100
 #include <Arduino.h> // Arduino 1.0
 #else
-#include <Wprogram.h> // Arduino 0022
+#include <WProgram.h> // Arduino 0022
 #endif
 
 void LiquidCrystalBase::begin(byte cols, byte lines, byte dotsize) {

--- a/PortsSHT11.cpp
+++ b/PortsSHT11.cpp
@@ -10,7 +10,7 @@
 #if ARDUINO>=100
 #include <Arduino.h> // Arduino 1.0
 #else
-#include <Wprogram.h> // Arduino 0022
+#include <WProgram.h> // Arduino 0022
 #endif
 
 enum {

--- a/RF12.cpp
+++ b/RF12.cpp
@@ -9,7 +9,7 @@
 #if ARDUINO >= 100
 #include <Arduino.h> // Arduino 1.0
 #else
-#include <Wprogram.h> // Arduino 0022
+#include <WProgram.h> // Arduino 0022
 #endif
 
 // #define OPTIMIZE_SPI 1  // uncomment this to write to the RFM12B @ 8 Mhz

--- a/RF12sio.cpp
+++ b/RF12sio.cpp
@@ -6,7 +6,7 @@
 #if ARDUINO>=100
 #include <Arduino.h> // Arduino 1.0
 #else
-#include <Wprogram.h> // Arduino 0022
+#include <WProgram.h> // Arduino 0022
 #endif
 
 #define DEBUG 0


### PR DESCRIPTION
Transmit-only clients, which wake sleep/rf12sleep mode to transmit data usually do something like this:

```
rf12_sleep(RF12_WAKEUP);
while (!rf12_canSend())
  rf12_recvDone();
rf12_sendStart(...);
rf12_sendWait(...);
rf12_sleep(RF12_SLEEP);
```

When the RF12M wakes up, the first call to canSend returns false, because rxstate == TXIDLE, so recvDone is executed once. This first call enables the receiver. Because the receiver takes several ms to start up after a sleep, the second call to canSend will always return true. There just isn't long enough between the calls for any data to be received or the receiver to even become operational.

This patch looks completely unrelated but really what it does is removes the reliance on canSend completing successfully. When the RF returns from sleep, it is already in "RF_IDLE_MODE" and rxstate is already TXIDLE. The only thing canSend is doing is forcing rf12_grp to group, this can be eliminated by using group directly during CRC calculation and transmit. The RF12.cpp code size is the same, and transmit-only clients now may transmit directly without checking a receive. If you try this without this patch, it transmits a packet for group 0.

```
rf12_sleep(RF12_WAKEUP);
rf12_sendStart(...);
rf12_sendWait(...);
rf12_sleep(RF12_SLEEP);
```
