### PR TITLE
arduino-tiny fixed their print.h to reflect Arduino >=1.0 IDE, the workound is therefore no longer required.

### DIFF
--- a/Ports.cpp
+++ b/Ports.cpp
@@ -390,7 +390,7 @@ void UartPlug::flush () {
     in = out;
 }
 
-WRITE_RESULT UartPlug::write (byte data) {
+size_t UartPlug::write (byte data) {
     regSet(THR, data);
     dev.stop();
 #if ARDUINO >= 100 && !defined(__AVR_ATtiny84__) && !defined(__AVR_ATtiny85__) && !defined(__AVR_ATtiny44__) && !defined(__AVR_ATtiny45__)

--- a/Ports.h
+++ b/Ports.h
@@ -13,13 +13,6 @@
 #include <avr/pgmspace.h>
 //#include <util/delay.h>
 
-// keep the ATtiny85 on the "old" conventions until arduino-tiny gets fixed
-#if ARDUINO >= 100 && !defined(__AVR_ATtiny84__) && !defined(__AVR_ATtiny85__) && !defined(__AVR_ATtiny44__) && !defined(__AVR_ATtiny45__)
-#define WRITE_RESULT size_t
-#else
-#define WRITE_RESULT void
-#endif
-
 class Port {
 protected:
     uint8_t portNum;
@@ -322,7 +315,7 @@ public:
     byte available();
     int read();
     void flush();
-    virtual WRITE_RESULT write(byte);
+    virtual size_t write(byte);
 };
 
 // interface for the Dimmer Plug - see http://jeelabs.org/dp1

--- a/PortsLCD.cpp
+++ b/PortsLCD.cpp
@@ -181,7 +181,7 @@ inline void LiquidCrystalBase::command(byte value) {
   send(value, LOW);
 }
 
-inline WRITE_RESULT LiquidCrystalBase::write(byte value) {
+inline size_t LiquidCrystalBase::write(byte value) {
   send(value, HIGH);
 #if ARDUINO >= 100 && !defined(__AVR_ATtiny84__) && !defined(__AVR_ATtiny85__) && !defined(__AVR_ATtiny44__) && !defined(__AVR_ATtiny45__)
   return 1;

--- a/PortsLCD.h
+++ b/PortsLCD.h
@@ -76,7 +76,7 @@ public:
 
   void createChar(byte, byte[]);
   void setCursor(byte, byte); 
-  virtual WRITE_RESULT write(byte);
+  virtual size_t write(byte);
   void command(byte);
 protected:
   virtual void config() =0;


### PR DESCRIPTION
This pull request will make arduino-tiny and the Jeelib work out of the box with Arduino 1.0 and higher. 
