### PR TITLE
Added functionality for Arduino Leonardo to set RF12B CS pin

### DIFF
--- a/RF12.cpp
+++ b/RF12.cpp
@@ -145,20 +145,19 @@ static uint32_t seqNum;             // encrypted send sequence number
 static uint32_t cryptKey[4];        // encryption key to use
 void (*crypter)(uint8_t);           // does en-/decryption (null if disabled)
 
-// function to set chip select pin from within sketch
+				    // function to set chip select pin from within sketch
 void rf12_set_cs(uint8_t pin)
 {
-#if defined(__AVR_ATmega32U4__) //Arduino Leonardo 
-  if (pin==10) cs_pin=6; 	// Dig10, PB6     
-  if (pin==9)  cs_pin=5; 	// Dig9,  PB5	
-  if (pin==8)  cs_pin=4; 	// Dig8,  PB4            
-#else 			   	// ATmega168, ATmega328, etc.
-  if (pin==10) cs_pin = 2; 	// Dig10, PB2
-  if (pin==9) cs_pin = 1;  	// Dig9,  PB1
-  if (pin==8) cs_pin = 0;  	// Dig8,  PB0
+#if defined(__AVR_ATmega32U4__)     //Arduino Leonardo 
+  if (pin==10) cs_pin=6; 	    // Dig10, PB6     
+  if (pin==9)  cs_pin=5; 	    // Dig9,  PB5	
+  if (pin==8)  cs_pin=4; 	    // Dig8,  PB4            
+#elif defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) // ATmega168, ATmega328, etc.
+  if (pin==10) cs_pin = 2; 	    // Dig10, PB2
+  if (pin==9) cs_pin = 1;  	    // Dig9,  PB1
+  if (pin==8) cs_pin = 0;  	    // Dig8,  PB0
   }
 #endif
-
 }
 
 


### PR DESCRIPTION
Added functionality for Arduino Leonardo to utilise rf12_set_cs(x) function where x is the Arduino digital pin to be used as RF12B's CS pin. Only digital 10,9 or 8 can be used since they are on the same port. If rf12_set_cs(x) is not called JeeLib will default to standard library pin definitions (digital 10 for Arduino Uno and Leonardo) .
