### PR TITLE
syncRecv sketch only wakes early when no packets lost?

### DIFF
--- a/examples/RF12/syncRecv/syncRecv.ino
+++ b/examples/RF12/syncRecv/syncRecv.ino
@@ -112,7 +112,7 @@ static bool optimalSleep () {
 
   // make a prediction for when the next packet should arrive
   uint32_t predict = lastRecv + (lost + 1) * estimate;
-  word sleep = predict - now - (lost ? 0 : window);
+  word sleep = predict - now - (lost ? window : 0);
   radioSleep(sleep);
 
   // listen to the radio until one window past predicted time


### PR DESCRIPTION
I was playing with some of the code from the syncRecv sketch, trying to force the code to "miss" a packet to observe if it could get back into sync. However, I found that once a packet was missed, there was a much higher chance of more packets going missing.

I looked at the code and it seems if there are 0 packets lost since the last receive, the code wakes (window) milliseconds earlier than the predicted time. If 1 or more packets have been lost, then the code tries to wake exactly at the time of predicted receive. Isn't this logic backward? That the receiver should listen from (predict - window) to (predict + window) if data has gone missing, rather than further restricting the amount of time the receiver is on?

This may be a moot point because when I adjust the code as attached, it performs pretty poorly, usually waking too late to get the receiver on in time to receive the packet (although only about a 1 in 20 chance of a missed receive). What I've actually done in my test is to always shrink receive for 2 \* window, and adjusted the MIN_WIN down to 8 and MAX_WIN down to 512 to account for the doubled window.

```
word sleep = predict - now - window;
```
