### PR TITLE
Bugfix in scheduler

### DIFF
--- a/Ports.cpp
+++ b/Ports.cpp
@@ -1172,7 +1172,11 @@ char Scheduler::poll() {
                     tasks[i] -= lowest;
                 }
             }
-        }
+        } else {
+			// must turn off timer or it might overflow if its poll-method
+			// is not called within 5535 milliseconds, i.e. if no tasks are scheduled
+			ms100.set(0);
+		}
         remaining = lowest;
     } else if (remaining == ~0U) //remaining == ~0 means nothing running
         return -2;


### PR DESCRIPTION
Fixed bug where scheduler's millitimer might overflow if no tasks are scheduled for over 5.5 seconds
