### PR TITLE
Added 'v' command to display script version. This can be queried by seri...

### DIFF
--- a/examples/RF12/RF12demo/RF12demo.ino
+++ b/examples/RF12/RF12demo/RF12demo.ino
@@ -701,6 +701,9 @@ static void handleInput (char c) {
       case 'x': // set reporting mode to hex (1) or decimal (0)
         useHex = value;
         break;
+      case 'v': //display the interpreter version
+        displayVersion(1);
+        break;
     }
     value = top = 0;
     memset(stack, 0, sizeof stack);
@@ -718,9 +721,15 @@ static void handleInput (char c) {
     showHelp();
 }
 
+void displayVersion(uint8_t newline ) {
+  Serial.print("\n[RF12demo.10]");
+  if(newline!=0)  Serial.println();
+
+}
+
 void setup() {
   Serial.begin(SERIAL_BAUD);
-  Serial.print("\n[RF12demo.10]");
+  displayVersion(0);
   activityLed(0);
 
   if (rf12_config()) {


### PR DESCRIPTION
...al drivers to determine the scripts name/version and imply capabilities. Examples would be:

Allow a serial driver to determine this sketch is RF12demo.10 and therefore imply that it supports the:
  band,group,node,header,data>
sending format, as well as:
  byte,byte,byte,byte,node,s syntax.

This is especially important for serial connections where the connection may not be able to be be reset (lack of RST etc) for example just connecting PWR/GND TX/RX of a gpio.

This appears to be a non-breaking change.

I would be happy for sketch to report .10 still, but a .11 would also be fine on my part. I would also be happy if you implement this in a different way to achieve the same result.

--lightbulb
