### PR TITLE
Update RF12.cpp

### DIFF
--- a/RF12.cpp
+++ b/RF12.cpp
@@ -70,7 +70,7 @@
 
 #elif defined(__AVR_ATmega32U4__) //Arduino Leonardo 
 
-#define RFM_IRQ     3       // PD0, INT0, Digital3 
+#define RFM_IRQ     0       // PD0, INT0, Digital3 
 #define SS_DDR      DDRB
 #define SS_PORT     PORTB
 #define SS_BIT      6       // Dig10, PB6


### PR DESCRIPTION
Hi JCW,
the IRQ pin for ATMega32u4 is wrong , even contradicts with the comment on that line. Using 0 works.
Martin