### PR TITLE
RF69 fixes

### DIFF
--- a/RF69.cpp
+++ b/RF69.cpp
@@ -187,7 +187,7 @@ void RF69::sendStart_compat (uint8_t hdr, const void* ptr, uint8_t len) {
     for (int i = 0; i < len; ++i)
         rf12_data[i] = ((const uint8_t*) ptr)[i];
     rf12_hdr = hdr & RF12_HDR_DST ? hdr : (hdr & ~RF12_HDR_MASK) + node;  
-    rf12_crc = _crc16_update(~0, group);
+    crc = _crc16_update(~0, group);
     rxstate = - (2 + rf12_len); // preamble and SYN1/SYN2 are sent by hardware
     flushFifo();
     setMode(MODE_TRANSMITTER);

--- a/RF69_avr.h
+++ b/RF69_avr.h
@@ -60,6 +60,9 @@ static void spiConfigPins () {
 #define SPI_MISO    4     // PA6, pin 7
 #define SPI_MOSI    5     // PA5, pin 8
 #define SPI_SCK     6     // PA4, pin 9
+#define SPI_MISO    6     // PA6, pin 7
+#define SPI_MOSI    5     // PA5, pin 8
+#define SPI_SCK     4     // PA4, pin 9
 
 static void spiConfigPins () {
     SS_PORT |= _BV(SS_BIT);

--- a/RF69_avr.h
+++ b/RF69_avr.h
@@ -57,9 +57,6 @@ static void spiConfigPins () {
 #define SS_BIT      1
 
 #define SPI_SS      1     // PB1, pin 3
-#define SPI_MISO    4     // PA6, pin 7
-#define SPI_MOSI    5     // PA5, pin 8
-#define SPI_SCK     6     // PA4, pin 9
 #define SPI_MISO    6     // PA6, pin 7
 #define SPI_MOSI    5     // PA5, pin 8
 #define SPI_SCK     4     // PA4, pin 9


### PR DESCRIPTION
There were two issues I ran across while using an RF69 in RF12 compatibility mode:
1) Checksums for ACKs are not correct...it was referencing the wrong crc variable
2) Pin numbers for the attiny84 was "reversed"
Otherwise, it's working great!  Thanks!