### PR TITLE
Add option to skip Jeelib header byte

### DIFF
--- a/RF12.cpp
+++ b/RF12.cpp
@@ -337,7 +337,7 @@ static void rf12_interrupt () {
         uint8_t out;
 
         if (rxstate < 0) {
-            uint8_t pos = 3 + RF12_COMPAT + rf12_len + rxstate++;
+            uint8_t pos = 3 + RF12_COMPAT + rf12_len + rf12_skip + rxstate++;
             out = rf12_buf[pos];
             rf12_crc = crc_update(rf12_crc, out);
 #if RF12_COMPAT
@@ -347,7 +347,7 @@ static void rf12_interrupt () {
             switch (rxstate) {
                 case TXSYN1: out = 0x2D; break;
                 case TXSYN2: out = group;
-            uint8_t pos = 3 + RF12_COMPAT + rf12_len + rf12_skip + rxstate++;
+                             rxstate = - (3 + RF12_COMPAT + rf12_len);
                              break;
 #if RF12_COMPAT
                 case TXCRC1: out = ~rf12_crc >> 8; break;

--- a/RF12.h
+++ b/RF12.h
@@ -108,9 +108,9 @@ uint8_t rf12_recvDone(void);
 /// @return true when a new transmission may be started with rf12_sendStart().
 uint8_t rf12_canSend(void);
 
-/// Call this is skip transmission of Jeelib specific header bytes
-void rf12_skip_hdr (uint8_t skip);
-
+/// Call this to skip transmission of specific bytes in rf12_buf
+/// Default value 2 skips the Jeelib header enabling non-Jeelib FSK packets 
+void rf12_skip_hdr (uint8_t skip=2);
 /// Call this only when rf12_recvDone() or rf12_canSend() return true.
 void rf12_sendStart(uint8_t hdr);
 /// Call this only when rf12_recvDone() or rf12_canSend() return true.

--- a/RF12.h
+++ b/RF12.h
@@ -108,6 +108,9 @@ uint8_t rf12_recvDone(void);
 /// @return true when a new transmission may be started with rf12_sendStart().
 uint8_t rf12_canSend(void);
 
+/// Call this is skip transmission of Jeelib specific header bytes
+void rf12_skip_hdr (uint8_t skip);
+
 /// Call this only when rf12_recvDone() or rf12_canSend() return true.
 void rf12_sendStart(uint8_t hdr);
 /// Call this only when rf12_recvDone() or rf12_canSend() return true.

--- a/RF69.cpp
+++ b/RF69.cpp
@@ -4,6 +4,8 @@
 
 #define REG_FIFO            0x00
 #define REG_OPMODE          0x01
+#define REG_BITRATEMSB      0x03
+#define REG_BITRATELSB      0x04
 #define REG_FRFMSB          0x07
 #define REG_AFCFEI          0x1E
 #define REG_RSSIVALUE       0x24
@@ -52,7 +54,7 @@ namespace RF69 {
 
 static volatile uint8_t rxfill;     // number of data bytes in rf12_buf
 static volatile int8_t rxstate;     // current transceiver state
-
+volatile uint8_t rf69_skip = 0;     // header bytes to skip
 static ROM_UINT8 configRegs_compat [] ROM_DATA = {
   0x01, 0x04, // OpMode = standby
   0x02, 0x00, // DataModul = packet mode, fsk
@@ -192,6 +194,10 @@ uint16_t RF69::recvDone_compat (uint8_t* buf) {
     return ~0; // keep going, not done yet
 }
 
+void RF69::skip_hdr (uint8_t skip) {
+    rf69_skip = skip;
+}
+
 void RF69::sendStart_compat (uint8_t hdr, const void* ptr, uint8_t len) {
     rf12_buf[2] = len;
     for (int i = 0; i < len; ++i)
@@ -209,12 +215,13 @@ void RF69::sendStart_compat (uint8_t hdr, const void* ptr, uint8_t len) {
         if ((readReg(REG_IRQFLAGS2) & IRQ2_FIFOFULL) == 0) {
             uint8_t out = 0xAA;
             if (rxstate < 0) {
-                out = recvBuf[3 + rf12_len + rxstate];
+                out = recvBuf[3 + rf12_len + rf69_skip + rxstate];
                 crc = _crc16_update(crc, out);
             } else {
                 switch (rxstate) {
                     case TXCRC1: out = crc; break;
-                    case TXCRC2: out = crc >> 8; break;
+                    case TXCRC2: out = crc >> 8; 
+                    rf69_skip = 0; // Cancel frame skip if applicable                    break;
                 }
             }
             writeReg(REG_FIFO, out);

--- a/RF69.cpp
+++ b/RF69.cpp
@@ -221,7 +221,8 @@ void RF69::sendStart_compat (uint8_t hdr, const void* ptr, uint8_t len) {
                 switch (rxstate) {
                     case TXCRC1: out = crc; break;
                     case TXCRC2: out = crc >> 8; 
-                    rf69_skip = 0; // Cancel frame skip if applicable                    break;
+                    rf69_skip = 0; // Cancel frame skip if applicable                    
+                    break;
                 }
             }
             writeReg(REG_FIFO, out);

--- a/RF69.h
+++ b/RF69.h
@@ -15,6 +15,9 @@ namespace RF69 {
     
     void configure_compat ();
     uint16_t recvDone_compat (uint8_t* buf);
+/// Call this to skip transmission of specific bytes in rf69_buf
+/// Default value 2 skips the Jeelib header enabling non-Jeelib FSK packets 
+    void skip_hdr (uint8_t skip=2);
     void sendStart_compat (uint8_t hdr, const void* ptr, uint8_t len);
     void interrupt_compat();
 }

--- a/RF69_compat.cpp
+++ b/RF69_compat.cpp
@@ -83,7 +83,11 @@ uint8_t rf69_canSend () {
 }
 
 // void rf69_sendStart (uint8_t hdr) {
+
 // }
+void rf69_skip_hdr (uint8_t skip) {
+    RF69::skip_hdr(skip);
+}
 
 void rf69_sendStart (uint8_t hdr, const void* ptr, uint8_t len) {
     RF69::sendStart_compat(hdr, ptr, len);

--- a/RF69_compat.h
+++ b/RF69_compat.h
@@ -20,6 +20,7 @@
 #define rf12_configSilent   rf69_configSilent
 #define rf12_recvDone       rf69_recvDone
 #define rf12_canSend        rf69_canSend
+#define rf12_skip_hdr       rf69_skip_hdr
 #define rf12_sendStart      rf69_sendStart
 #define rf12_sendNow        rf69_sendNow
 #define rf12_sendWait       rf69_sendWait

--- a/examples/RF12/RF12demo/RF12demo.ino
+++ b/examples/RF12/RF12demo/RF12demo.ino
@@ -626,6 +626,16 @@ void loop () {
         if (rf12_crc == 0)
             showString(PSTR("OK"));
         else {
+
+            if(rf12_buf[0] == 212 && (rf12_buf[1] | rf12_buf[2]) == rf12_buf[3] && rf12_buf[4] == 90){
+                showString(PSTR("Salus "));
+                showByte(rf12_buf[1]);
+                printOneChar(':');
+                showByte(rf12_buf[2]);
+                Serial.println();
+//                return;
+            }            
+            
             if (config.quiet_mode)
                 return;
             showString(PSTR(" ?"));


### PR DESCRIPTION
These changes add an option to skip a default 2 bytes from the Jeelib RF transmission. This enables FSK packets to be transmitted to non Jeelib devices. This effect is achieved by calling rf12_skip_hdr() or alternatively rf12_skip_hdr(2).