### PR TITLE
Additional Sleepy options offered.

### DIFF
--- a/Ports.cpp
+++ b/Ports.cpp
@@ -1253,7 +1253,7 @@ word Sleepy::idleTimer (byte prescale) {
     if (millisAdjust == 2) break;
     if (!(++timeIdle + 1)) break;     // Might detect just before overflow
     }
-    PRR = savePRR;                //
+    PRR = savePRR;                // re-enable what we disabled
     TIMSK0 = saveTIMSK0;          // re-enable what we disabled
     return timeIdle;              // Complete intervals
 }

--- a/Ports.cpp
+++ b/Ports.cpp
@@ -1174,6 +1174,90 @@ void Sleepy::watchdogEvent() {
     ++watchdogCounter;
 }
 
+void Sleepy::idle () {
+    set_sleep_mode(SLEEP_MODE_IDLE);
+    sleep_enable();
+    sei();        // Enable interrupts    
+    sleep_cpu();  // Sleep will happen irrespective of interrupts    
+    cli();        // Interrupts will be disabled no matter what happens
+    // wake up here effectively
+    sleep_disable();
+}
+
+word Sleepy::idleSomeTime (unsigned int secs) {
+    unsigned int timeLeft = secs;
+    word millisAdjust;
+    byte saveTIMSK0 = TIMSK0;
+#ifndef PRR
+#define PRR PRR0
+#endif   
+    byte savePRR = PRR;
+    TIMSK0 &= ~(1 << TOIE0);      // Reduce background interrupts, millis()
+    PRR |= (1 << PRTIM0);         // Power down Timer0
+    while (timeLeft) {
+        millisAdjust = 2;         // If we are interrupted assume 2ms
+        watchdogCounter = 0;
+        watchdogInterrupts(6);    // 1024ms
+        idle(); 
+        watchdogInterrupts(-1);   // off
+        if (watchdogCounter != 0) {
+            millisAdjust = 1024;  // Wasn't interrupted for 1024ms
+        }
+// Update millis as we go, if we are interrupted time(ms) should have moved on
+// for the interrupting process        
+#if defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny85__) || defined (__AVR_ATtiny44__) || defined (__AVR_ATtiny45__)
+        extern volatile unsigned long millis_timer_millis;
+        millis_timer_millis += millisAdjust;
+#else
+        extern volatile unsigned long timer0_millis;
+        timer0_millis += millisAdjust;
+#endif
+    if (millisAdjust == 2) break;
+    --timeLeft;       
+    }
+    PRR = savePRR;                // re-enable what we disabled
+    TIMSK0 = saveTIMSK0;          // re-enable what we disabled
+    return timeLeft;
+}
+
+word Sleepy::idleTimer (byte prescale) {
+    unsigned int timeIdle = 0;
+    word millisAdjust;
+    byte saveTIMSK0 = TIMSK0;
+    byte savePRR = PRR;
+    TIMSK0 &= ~(1 << TOIE0);      // Reduce background interrupts, millis()
+#ifndef PRR
+#define PRR PRR0
+#endif   
+    PRR |= (1 << PRTIM0);         // Power down Timer0
+    while (1) {
+        millisAdjust = 2;         // If we are interrupted assume 2ms passed
+        watchdogCounter = 0;
+        watchdogInterrupts(prescale);    // 6 = 1024ms
+        idle(); 
+        watchdogInterrupts(-1);   // off
+        
+        // because there are lots of Serial.print interrupts around
+        if (watchdogCounter != 0) {
+            millisAdjust = 16 << prescale;  // Wasn't interrupted
+        }
+// Update millis as we go, if we are interrupted time(ms) should have moved on
+// for the interrupting process        
+#if defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny85__) || defined (__AVR_ATtiny44__) || defined (__AVR_ATtiny45__)
+        extern volatile unsigned long millis_timer_millis;
+        millis_timer_millis += millisAdjust;
+#else
+        extern volatile unsigned long timer0_millis;
+        timer0_millis += millisAdjust;
+#endif
+    if (millisAdjust == 2) break;
+    if (!(++timeIdle + 1)) break;     // Might detect just before overflow
+    }
+    PRR = savePRR;                //
+    TIMSK0 = saveTIMSK0;          // re-enable what we disabled
+    return timeIdle;              // Complete intervals
+}
+
 Scheduler::Scheduler (byte size) : remaining (~0), maxTasks (size) {
     byte bytes = size * sizeof *tasks;
     tasks = (word*) malloc(bytes);

--- a/Ports.h
+++ b/Ports.h
@@ -359,6 +359,33 @@ public:
 
     /// This must be called from your watchdog interrupt code.
     static void watchdogEvent();
+    
+    /// enter idle state
+    static void idle();
+        
+    /// Idle a while waiting for a relevant interrupt
+    static unsigned int idleSomeTime(unsigned int secs);
+    
+    /// Idle forever waiting for an interrupt
+    static unsigned int idleTimer(byte prescale); 
+
+    /// Watchdog Timer Prescale intervals
+    ///     w w w w
+    ///     d d d d
+    ///     p p p p
+    ///     3 2 1 0
+    /// 0x0 0 0 0 0 2K (2048) cycles 16 ms
+    /// 0x1 0 0 0 1 4K (4096) cycles 32 ms
+    /// 0x2 0 0 1 0 8K (8192) cycles 64 ms
+    /// 0x3 0 0 1 1 16K (16384) cycles 0.125 s
+    /// 0x4 0 1 0 0 32K (32768) cycles 0.25 s
+    /// 0x5 0 1 0 1 64K (65536) cycles 0.5 s
+    /// 0x6 0 1 1 0 128K (131072) cycles 1.0 s
+    /// 0x7 0 1 1 1 256K (262144) cycles 2.0 s
+    /// 0x8 1 0 0 0 512K (524288) cycles 4.0 s
+    /// 0x9 1 0 0 1 1024K (1048576) cycles 8.0 s
+    /// All other values are reserved
+            
 };
 
 /// simple task scheduler for times up to 6000 seconds


### PR DESCRIPTION
Do you think these option have a place in the Master? They require stray interrupts to be managed with Serial.flush() etc. 

word Sleepy::idleSomeTime (unsigned int secs)
This waits for an int of seconds or any interrupt to exit, which ever comes first.

word Sleepy::idleTimer (byte prescale)
Similar to above this will idle until 65535 * the 328P prescaler value or exit from any interrupt. 
Both the above are supported by:
void Sleepy::idle ()
