### PR TITLE
Sleepy::loseSomeTime() desactive watchdog

### DIFF
--- a/Ports.cpp
+++ b/Ports.cpp
@@ -1099,19 +1099,21 @@ const word* ColorPlug::chromaCCT () {
 // ISR(WDT_vect) { Sleepy::watchdogEvent(); }
 
 static volatile byte watchdogCounter;
+static byte backupMode = 0;
 
 void Sleepy::watchdogInterrupts (char mode) {
+#ifndef WDTCSR
+#define WDTCSR WDTCR
+#endif
     // correct for the fact that WDP3 is *not* in bit position 3!
     if (mode & bit(3))
         mode ^= bit(3) | bit(WDP3);
     // pre-calculate the WDTCSR value, can't do it inside the timed sequence
     // we only generate interrupts, no reset
-    byte wdtcsr = mode >= 0 ? bit(WDIE) | mode : 0;
+    byte wdtcsr = mode >= 0 ? bit(WDIE) | mode : backupMode;
+    if(mode>=0) backupMode = WDTCSR;
     MCUSR &= ~(1<<WDRF);
     ATOMIC_BLOCK(ATOMIC_FORCEON) {
-#ifndef WDTCSR
-#define WDTCSR WDTCR
-#endif
         WDTCSR |= (1<<WDCE) | (1<<WDE); // timed sequence
         WDTCSR = wdtcsr;
     }


### PR DESCRIPTION
Sleepy::loseSomeTime() need to configure watchDog in interupt mode. But after loseSomeTime finish, it is better to put back old whatchdog configuration in place of completly desactive watchdog