### PR TITLE
Ports.cpp updated to flush serial pending data before powerdown

### DIFF
--- a/Ports.cpp
+++ b/Ports.cpp
@@ -1138,6 +1138,12 @@ void Sleepy::powerDown () {
     ADCSRA = adcsraSave;
 }
 
+/// This method waits Serial to send data via UART before powering down.
+void Sleepy::flushAndPowerDown () {
+    Serial.flush();
+    powerDown();
+}
+
 byte Sleepy::loseSomeTime (word msecs) {
     byte ok = 1;
     word msleft = msecs;

--- a/Ports.h
+++ b/Ports.h
@@ -345,6 +345,10 @@ public:
     
     /// enter low-power mode, wake up with watchdog, INT0/1, or pin-change
     static void powerDown ();
+
+    /// flushes pending data in Serial and then enter low-power mode, wake up
+    /// with watchdog, INT0/1, or pin-change
+    static void flushAndPowerDown ();
     
     /// Spend some time in low-power mode, the timing is only approximate.
     /// @param msecs Number of milliseconds to sleep, in range 0..65535.


### PR DESCRIPTION
This commit updates Sleepy::powerDown method to check Serial object and forcing a flush before sleeping the MCU. Without flushing, UART communication for debugging is almost impossible.