### PR TITLE
Change RxBw to proper value for 90KHz TX-dev.

### DIFF
--- a/RF12.cpp
+++ b/RF12.cpp
@@ -641,7 +641,7 @@ uint8_t rf12_initialize (uint8_t id, uint8_t band, uint8_t g, uint16_t f) {
     rf12_xfer(0x80C7 | (band << 4)); // EL (ena TX), EF (ena RX FIFO), 12.0pF
     rf12_xfer(0xA000 + frequency); // 96-3960 freq range of values within band
     rf12_xfer(0xC606); // approx 49.2 Kbps, i.e. 10000/29/(1+6) Kbps
-    rf12_xfer(0x94A2); // VDI,FAST,134kHz,0dBm,-91dBm
+    rf12_xfer(0x9482); // VDI,FAST,134kHz,0dBm,-91dBm
     rf12_xfer(0xC2AC); // AL,!ml,DIG,DQD4
     if (group != 0) {
         rf12_xfer(0xCA83); // FIFO8,2-SYNC,!ff,DR


### PR DESCRIPTION
0x94A2 means 134KHz RX-bandwidth. With +/- 90 KHz FSK deviation 200 KHz is a better choice. Else modulation is lost in the RX-filter.