### PR TITLE
Update RF12.cpp

### DIFF
--- a/RF12.cpp
+++ b/RF12.cpp
@@ -82,9 +82,9 @@
 #define SS_BIT      1
 
 #define SPI_SS      1     // PB1, pin 3
-#define SPI_MISO    4     // PA6, pin 7
+#define SPI_MISO    6     // PA6, pin 7
 #define SPI_MOSI    5     // PA5, pin 8
-#define SPI_SCK     6     // PA4, pin 9
+#define SPI_SCK     4     // PA4, pin 9
 
 #elif defined(__AVR_ATmega32U4__) //Arduino Leonardo
 


### PR DESCRIPTION
Update the pins for ATtiny84 to match the corrected pins in RF69_avr.h. Harmonizing the two makes sense. The scheme that has been in RF69_avr.h is the more modern, clockwise mapping in which MISO (PA6) is numbered 6, and SCK (PA4) is numbered 4.